### PR TITLE
Fixed RuntimeError when GEOIP_CACHE config setting was unset

### DIFF
--- a/flask_geoip/__init__.py
+++ b/flask_geoip/__init__.py
@@ -31,7 +31,7 @@ class GeoIP(object):
             self.init_app(app)
 
     def init_app(self, app):
-        app.config.setdefault('GEOIP_CACHE', pygeoip.STANDARD)
+        app.config.setdefault('GEOIP_CACHE', 'STANDARD')
         cache_setting_name = app.config['GEOIP_CACHE']
         cache_setting = CACHE_MAP.get(app.config['GEOIP_CACHE'])
 


### PR DESCRIPTION
The original default set was an integer value (`pygeoip.STANDARD`), which flask-geoip then tried to look up in the `CACHE_MAP` dict. Setting a default of 'STANDARD' works as expected.
